### PR TITLE
Bar scala module override

### DIFF
--- a/bar/build.sc
+++ b/bar/build.sc
@@ -6,10 +6,10 @@ object bar extends BarCross(None)
 
 class BarCross(val fooDepOverride: Option[ScalaModule] = None) extends ScalaModule {
   def scalaVersion = "2.12.4"
-  def ivyDeps = fooDepOverride match {
-    case Some(_) => Agg(ivy"org.scalatest::scalatest:3.0.1") // Agg() doesn't work, arbitrary and unused
+  def ivyDeps = T { fooDepOverride match {
+    case Some(_) => Agg()
     case None => Agg(ivy"com.jackkoenig::foo:0.0.1")
-  }
+  } }
   def moduleDeps = fooDepOverride match {
     case Some(dep) => Seq(dep)
     case None => Seq()

--- a/bar/build.sc
+++ b/bar/build.sc
@@ -2,7 +2,16 @@
 import mill._
 import scalalib._
 
-object bar extends ScalaModule {
+object bar extends BarCross(None)
+
+class BarCross(val fooDepOverride: Option[ScalaModule] = None) extends ScalaModule {
   def scalaVersion = "2.12.4"
-  override def ivyDeps = Agg(ivy"com.jackkoenig::foo:0.0.1")
+  def ivyDeps = fooDepOverride match {
+    case Some(_) => Agg(ivy"org.scalatest::scalatest:3.0.1") // Agg() doesn't work, arbitrary and unused
+    case None => Agg(ivy"com.jackkoenig::foo:0.0.1")
+  }
+  def moduleDeps = fooDepOverride match {
+    case Some(dep) => Seq(dep)
+    case None => Seq()
+  }
 }

--- a/build.sc
+++ b/build.sc
@@ -5,7 +5,9 @@ import scalalib._
 import $file.bar.build
 import $file.foo.build
 
+object bar2 extends bar.build.BarCross(Some(foo.build.foo))
+
 object top extends ScalaModule {
   def scalaVersion = "2.12.4"
-  override def moduleDeps = Seq(foo.build.foo, bar.build.bar)
+  override def moduleDeps = Seq(foo.build.foo, bar2)
 }


### PR DESCRIPTION
**This does not work**

This approach involves `bar` itself understanding that its ivy dependency on `foo` can be "overridden" with an optional `ScalaModule` argument. Then, `top` can create its own version of `bar`, `bar2`, and use a module dependency there.

With these changes, neither `bar` nor `bar2` show up as build targets according to `mill resolve _`