### PR TITLE
Refactor bar into BarModule and extend in the top build.sc

### DIFF
--- a/bar/build.sc
+++ b/bar/build.sc
@@ -2,7 +2,9 @@
 import mill._
 import scalalib._
 
-object bar extends ScalaModule {
+object bar extends BarModule
+
+trait BarModule extends ScalaModule {
   def scalaVersion = "2.12.4"
   override def ivyDeps = Agg(ivy"com.jackkoenig::foo:0.0.1")
 }

--- a/build.sc
+++ b/build.sc
@@ -1,11 +1,18 @@
 // build.sc
 import mill._
 import scalalib._
+import ammonite.ops._
 
 import $file.bar.build
 import $file.foo.build
 
+object bar2 extends bar.build.BarModule {
+  override def ivyDeps = T { Agg() }
+  override def moduleDeps = Seq(foo.build.foo)
+  override def millSourcePath = super.millSourcePath / up / 'bar / 'bar
+}
+
 object top extends ScalaModule {
   def scalaVersion = "2.12.4"
-  override def moduleDeps = Seq(foo.build.foo, bar.build.bar)
+  override def moduleDeps = Seq(bar2)
 }


### PR DESCRIPTION
**This works!**

In this version, `bar` becomes a trait `BarModule` so that it can be implemented in alternative ways. `top` then creates `bar2` that explicitly removes the ivy dependency (hopefully this can be done with a filter) and adds the module dependency on `foo`.

This seems to work just fine. Issues with it:
1. `millSourcePath` has to be fixed up, it would be nice if there were a way to set it based on `bar.build.BarModule`
2. For more complicated builds (imagine `bar` is a multi-module build itself), this requires a full parallel group of `Module`s in `top` that must correspond to each module in `bar`. Depending on how complex `bar` is, this could be a lot of boilerplate, duplicated code.